### PR TITLE
Make logo clickable

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -10,7 +10,7 @@ export const Header = (props) => {
 			<Grid align="center">
 				<HeaderRow align="baseline" justify="center">
 					<HeaderCol size={1} textAlign="left">
-						<h1>BrewMES</h1>
+						<StyledLink to="/" style={{fontWeight:'bold', fontSize:'2em'}}>BrewMES</StyledLink>
 					</HeaderCol>
 					<HeaderCol size={2}>
 						<Row justify="center" gap={20}>


### PR DESCRIPTION
Had to do it, sorry.

Closes #41 

The logo is now a link to the home view.

![image](https://user-images.githubusercontent.com/55458479/119396995-e1f64080-bcd5-11eb-9eb5-c2dbc3afaa22.png)
